### PR TITLE
Syslog Fix

### DIFF
--- a/bin/user/wns.py
+++ b/bin/user/wns.py
@@ -423,9 +423,7 @@ class WnsThread(weewx.restx.RESTThread):
         url = '%s?var=%s;%s;%s' % (self.server_url, 
                           self.station, self.api_key, __body)
 
-        if self.log_url:
-            loginf("url %s" % url)
-        elif weewx.debug >= 2:
+        if weewx.debug >= 2:
             logdbg("url: %s" % url)
 
         return url


### PR DESCRIPTION
Ein Fix für ein älteres Problem. Ich hätte das [Issue#1](https://github.com/roe-dl/weewx-wns/issues/1) nicht einfach schließen sollen.

Ich habe Zeile 530 auch noch auskommentiert, diese erscheint auch bei jeden Loop im Syslog.
`
loginf("GTS %s, %s loops" % (self.gts_value,_loop_ct))
`
Oder wären Parameter in der weewx.conf für das Logging sinnvoll? Mir würde das reichen.
`
INFO user.wns: GTS initialized 2022-01-01
`
Wenn es Probleme geben sollte, müsste Debug halt ran.